### PR TITLE
fix: add rootDir to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "target": "ES2017",
     "esModuleInterop": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "declarationDir": "./types",
     "declaration": true


### PR DESCRIPTION
## Summary
- TypeScript 6.x now requires `rootDir` to be explicitly set when `outDir` is configured
- Add `"rootDir": "./src"` to fix TS5011 error causing CI failures on all branches

## Test plan
- [ ] CI build passes